### PR TITLE
Add missing namespace for ServiceAccount

### DIFF
--- a/deploy/charts/hpa-operator/templates/service-account.yaml
+++ b/deploy/charts/hpa-operator/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "hpa-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     app: "{{ template "hpa-operator.fullname" . }}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?
Added missing namespace for ServiceAccount when deployed with `--namespace`

### Checklist
- [x] Related Helm chart(s) updated (if needed)