### PR TITLE
fix servicemonitor selectors

### DIFF
--- a/deploy/charts/hpa-operator/templates/service-monitor.yaml
+++ b/deploy/charts/hpa-operator/templates/service-monitor.yaml
@@ -15,9 +15,10 @@ spec:
     - path: /metrics
       port: https
   selector:
-    app: {{ template "hpa-operator.name" . }}
-    chart: {{ template "hpa-operator.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    matchLabels:
+      app: {{ template "hpa-operator.name" . }}
+      chart: {{ template "hpa-operator.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
Move the service monitor selectors under matchLabels


### Why?
Without change the servicemonitor errors:
ValidationError(ServiceMonitor.spec.selector): unknown field \"app\" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field \"chart\" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field \"heritage\" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector, ValidationError(ServiceMonitor.spec.selector): unknown field \"release\" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector

### Additional context

### Checklist
- [ x ] Related Helm chart(s) updated (if needed)

### To Do
